### PR TITLE
docs: fix path to logos in press-kit.md

### DIFF
--- a/adev/src/content/reference/press-kit.md
+++ b/adev/src/content/reference/press-kit.md
@@ -4,13 +4,13 @@ The logo graphics available for download on this page are provided under [CC BY 
 
 <docs-card-container>
   <docs-card title="Angular logos" href="https://drive.google.com/drive/folders/1IgcAwLDVZUz8ycnFa7T4_H6B4V4LhYUQ?usp=sharing" link="Download from Google Drive">
-    ![Angular wordmark gradient logo](./images/press-kit/angular_wordmark_gradient.png "Angular wordmark gradient logo")
-    ![Angular wordmark white logo](./images/press-kit/angular_wordmark_white.png "Angular wordmark white logo")
-    ![Angular wordmark black logo](./images/press-kit/angular_wordmark_black.png "Angular wordmark black logo")
+    ![Angular wordmark gradient logo](../images/press-kit/angular_wordmark_gradient.png "Angular wordmark gradient logo")
+    ![Angular wordmark white logo](../images/press-kit/angular_wordmark_white.png "Angular wordmark white logo")
+    ![Angular wordmark black logo](../images/press-kit/angular_wordmark_black.png "Angular wordmark black logo")
     Black and white are the default color variations and should be used in most circumstances. A gradient version of the icon and lockup is available in both static and animated formats and can be used in cases where a color icon is required.
   </docs-card>
   <docs-card title="Brand guidelines" href="https://drive.google.com/drive/folders/1gD5-kamfribnib6TH4-aqVZxjYaDZlCg?usp=drive_link" link="Download from Google Drive">
-    ![Angular animated gradient logo](./images/press-kit/angular_icon_gradient.gif "Angular animated gradient logo")
+    ![Angular animated gradient logo](../images/press-kit/angular_icon_gradient.gif "Angular animated gradient logo")
     Our brand guidelines folders contain the design files, guidance and community examples for how the brand can be adapted.
     Read more about adapting the logo in the section below.
   </docs-card>
@@ -36,18 +36,18 @@ If you have any questions on adapting the new logo, or updating your own, please
 Lean into the shape of Angular’s new logo by changing the logo colors to match your brand colors, flag, cause, etc.
 
 In this example, we’ve adapted the colors to create an Angular Pride logo variation:
-![Angular pride logo](./images/press-kit/angular_pride.png#small "Angular pride logo")
+![Angular pride logo](../images/press-kit/angular_pride.png#small "Angular pride logo")
 </docs-step>
 
 <docs-step title="Adapt the logo shape as your own">
 Lean into the shape of Angular’s new logo by adapting the shield to match your own brand.
 
 In this example, we’ve adapted the shield to create an Angular Signals logo variation:
-![Angular Signals logo](./images/press-kit/angular_signals.png#medium "Angular Signals logo")
+![Angular Signals logo](../images/press-kit/angular_signals.png#medium "Angular Signals logo")
 </docs-step>
 
 <docs-step title="Do’s and don’ts of adapting the brand">
-![Rhubarb the small cat](./images/press-kit/do_and_dont.png "Rhubarb the small cat")
+![Rhubarb the small cat](../images/press-kit/do_and_dont.png "Rhubarb the small cat")
 </docs-step>
 
 </docs-workflow>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
I noticed the logos where broken on https://angular.dev/press-kit# so fixed them. Looks md file was moved at some point, so the relative path to the images were broken.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
